### PR TITLE
Wk9874/add slice timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## [v1.1.1](https://github.com/simvue-io/connectors-fds/releases/tag/v1.1.0) - 2025-06-27
+
+* Added estimate of timestamps for each slice metric value to fix bug in Alert UI
+* Added attribute which can be toggled to disable uploading of input file
+
 ## [v1.1.0](https://github.com/simvue-io/connectors-fds/releases/tag/v1.1.0) - 2025-06-26
 
 * Added functionality to load historic FDS runs into Simvue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "simvue-fds"
-version = "1.1.0"
+version = "1.1.1"
 description = "Connector to allow you to easily add Simvue tracking and monitoring to FDS (Fire Dynamics Simulator) simulations."
 authors = [
     {name = "Matt Field",email = "matthew.field@ukaea.uk"}

--- a/simvue_fds/connector.py
+++ b/simvue_fds/connector.py
@@ -58,6 +58,7 @@ class FDSRun(WrappedRun):
     _slice_step: int = 0
     _step_tracker: dict = {}
     _parsing: bool = False
+    _parse_time: float = datetime.now().timestamp()
     _activation_times: bool = False
     _activation_times_data: typing.Dict[str, float] = {}
     _chid: str = ""
@@ -552,7 +553,20 @@ class FDSRun(WrappedRun):
                     ignore_zeros=self.slice_parse_ignore_zeros,
                 )
 
-            self.log_metrics(metrics, time=float(time_val), step=self._slice_step)
+            # Need to estimate timestamp which this measurement would correspond to
+            # Will use estimate = timestamp of last parse + (now - last parse) * (idx/len(times_out))
+            _timestamp_estimate: float = self._parse_time + (
+                datetime.now().timestamp() - self._parse_time
+            ) * ((time_idx + 1) / len(times_out))
+
+            self.log_metrics(
+                metrics,
+                time=float(time_val),
+                step=self._slice_step,
+                timestamp=datetime.fromtimestamp(_timestamp_estimate).strftime(
+                    DATETIME_FORMAT
+                ),
+            )
             self._slice_step += 1
 
         self._slice_processed_time = times_out[-1]

--- a/simvue_fds/connector.py
+++ b/simvue_fds/connector.py
@@ -571,7 +571,7 @@ class FDSRun(WrappedRun):
                 ),
             )
             self._slice_step += 1
-
+        self._parse_time = datetime.now().timestamp()
         self._slice_processed_time = times_out[-1]
         return True
 

--- a/simvue_fds/connector.py
+++ b/simvue_fds/connector.py
@@ -54,6 +54,9 @@ class FDSRun(WrappedRun):
     ulimit: typing.Union[str, int] = None
     fds_env_vars: typing.Dict[str, typing.Any] = None
 
+    # Users can set this before launching a simulation, if they want (not in launch to not bloat arguments required)
+    upload_input_file: bool = True
+
     _slice_processed_time: int = -1
     _slice_step: int = 0
     _step_tracker: dict = {}
@@ -590,7 +593,7 @@ class FDSRun(WrappedRun):
         self.log_event("Starting FDS simulation")
 
         # Save the FDS input file for this run to the Simvue server
-        if pathlib.Path(self.fds_input_file_path).exists:
+        if self.upload_input_file and pathlib.Path(self.fds_input_file_path).exists:
             self.save_file(self.fds_input_file_path, "input")
 
         # Set stack limit - analogous to 'ulimit -s' recommended in FDS documentation


### PR DESCRIPTION
# Hotfix - Estimate timestamps for slice parser

## Description of Bug(s) and Fix(es)
Due to the alert graphs on the UI using timestamps for their plots, need to add some estimate of the timestamp which each slice measurement would correspond to
## Testing Performed
- **Tested Software Version(s)**: 6.9.1
- **Tested Operating System(s)**: Ubuntu
- **Tested Python Version(s)**:  3.10
- **Tested Simvue Python API Version(s)**: 2.1.2

## Comments
Also resolves #5 

## Checklist
- [x] Code corresponds to the guidelines set out in the Contributing.md document
- [ ] ~Any new Python package requirements have been added as an Extra to the `pyproject.toml`~
- [ ] ~New unit tests have been added to check for this bug in the future~
- [x] All unit tests run and pass locally
- [x] Integration tests are passing in the CI
- [x] Code passes all pre-commit hooks
