### PR TITLE
Add fix for concatenated files

### DIFF
--- a/simvue_fds/connector.py
+++ b/simvue_fds/connector.py
@@ -1067,6 +1067,7 @@ class FDSRun(WrappedRun):
         self.slice_parser = None
         self._loading_historic_run = True
         self._grids_defined = False
+        self._concatenated_input_files = False
 
         # Find input file inside results dir
         _fds_files = list(pathlib.Path(results_dir).rglob("*.fds"))


### PR DESCRIPTION
# Hotfix - Support concatenated FDS files
## Description of Bug(s) and Fix(es)
FDS files can have a `&CATF` namespace, where you can specify other FDS files to dynamically load at runtime. This changes the CHID to `{chid}_cat`.

Will now check if CATF is present in the FDS file, and if so will update the CHID. It will also upload the concatenated input file once the simulation is complete.

Also added a small fix for slice parsing - if you ask to ignore zeros, there will now be a warning if the slice is entirely zero, and the summary metrics will be set to zero (previously it will crash as it tried to do .min() on an empty array)
## Testing Performed
- **Tested Software Version(s)**: FDS 6.9.1
- **Tested Operating System(s)**: Ubuntu
- **Tested Python Version(s)**: 3.10
- **Tested Simvue Python API Version(s)**: 2.2.2

## Links to Issues
#17 

## Checklist
- [ ] Code corresponds to the guidelines set out in the Contributing.md document
- [ ] Any new Python package requirements have been added as an Extra to the `pyproject.toml`
- [ ] New unit tests have been added to check for this bug in the future
- [ ] All unit tests run and pass locally
- [ ] Integration tests are passing in the CI
- [ ] Code passes all pre-commit hooks
