### PR TITLE
Fix for slice parsing returns two arrays

### DIFF
--- a/simvue_fds/connector.py
+++ b/simvue_fds/connector.py
@@ -652,6 +652,7 @@ class FDSRun(WrappedRun):
             # We will just use the first one, since they should be almost identical...
             if isinstance(values, tuple):
                 values = values[0]
+            if isinstance(coords, tuple):
                 coords = coords[0]
 
             # Get rid of values already uploaded, return if nothing left to upload


### PR DESCRIPTION
# Hotfix - Fix slice parsing return two arrays

## Description of Bug(s) and Fix(es)
Sometimes, if a slice is between two meshes, fdsreader will return two slice arrays in a tuple, one for each mesh. These should be basically the same, so we will just use the first one. Currently this breaks slice parsing due to trying to access indexes in a tuple instead of the expected ndarray

## Testing Performed
- **Tested Software Version(s)**: [Versions of the software which the fix has been tested against]
- **Tested Operating System(s)**: [Names of operating systems which the fix has been tested against]
- **Tested Python Version(s)**: [The python versions which the fix has been tested against]
- **Tested Simvue Python API Version(s)**: [Versions of the Python API which the fix has been tested against]

## Links to Issues
[Provide links to any issues which have been fixed as a result of this PR]

## Comments
[Add any other comments about this PR here]

## Checklist
- [ ] Code corresponds to the guidelines set out in the Contributing.md document
- [ ] Any new Python package requirements have been added as an Extra to the `pyproject.toml`
- [ ] New unit tests have been added to check for this bug in the future
- [ ] All unit tests run and pass locally
- [ ] Integration tests are passing in the CI
- [ ] Code passes all pre-commit hooks
