### PR TITLE
Add rectangle-extractor helper functions

### DIFF
--- a/simvue_fds/helpers.py
+++ b/simvue_fds/helpers.py
@@ -1,0 +1,211 @@
+"""Helpers for extracting useful information from FDS files."""
+
+import f90nml
+
+
+def read_obst_rectangles(
+    file_path: str, size: dict[str, float], heights: dict[str, list[float]]
+) -> list[dict[str, tuple[float, float] | float]]:
+    """Read all the obstacles from a specified horizontal region in an FDS file.
+
+    This determines which areas are 'blocked' from containing an item of a specified size.
+    The inputs are the path, the size of the object, and the heights of the floors to investigate.
+    This returns a dictionary containing the size and positions of all of
+    the rectangles that must be avoided along with their heights.
+
+    Parameters
+    ----------
+    file_path : str
+        Path to the FDS input file.
+
+    size : dict[str, float]
+        The 3 dimensional size/footprint of the object
+
+        Required keys are:
+        - "x" : horizontal width in the x-direction
+        - "y" : horizontal total width in the y-direction
+        - "z" : vertical height  in the z-direction
+
+    heights : dict[str, list[float]]
+        The floor levels to investigate.
+        Must contain key "z" with a list of heights.
+
+    Returns
+    -------
+    list[dict[str, tuple[float, float] | float]]
+        Rectangles representing regions in which the centre of the object cannot be located
+        Each item has the form::
+
+            {
+                "x": (x_min, x_max),
+                "y": (y_min, y_max),
+                "z": base_elevation,
+            }
+
+        A separate rectangle is returned for every matching obstacle and every
+        queried base elevation, so the same obstacle may appear multiple times
+        if it intersects multiple requested z layers.
+
+    Raises
+    ------
+    RuntimeError
+        Raised if any required size key ("x", "y", or "z") is
+        missing, or if heights does not contain "z".
+
+    Notes
+    -----
+    - Only OBST lines in the input file are considered, and XB values are used to determine sizes
+    - Vertical intersection is tested using strict inequalities, so an obstacle
+      whose bottom just touches the top of the object you're trying to place is not included
+    - The returned footprints use the FDS XB x/y bounds, then pads them by half
+      the supplied object size on each side.
+
+    Examples
+    --------
+    Read obstacle rectangles intersecting two floors from an FDS file::
+
+        rects = read_obst_rectangles(
+            "case.fds",
+            size={"x": 0.2, "y": 0.2, "z": 3.0},
+            heights={"z": [0.0, 3.0]},
+        )
+
+    A returned entry has the form::
+
+        {
+            "x": (1.9, 4.1),
+            "y": (0.4, 2.6),
+            "z": 0.0,
+        }
+
+    """
+    if "x" not in size:
+        raise RuntimeError(
+            '"x" width must be provided to read_obst_rectangles in the size dictionary'
+        )
+    if "y" not in size:
+        raise RuntimeError(
+            '"y" width must be provided to read_obst_rectangles in the size dictionary'
+        )
+    if "z" not in size:
+        raise RuntimeError(
+            '"z" height must be provided to read_obst_rectangles in the size dictionary'
+        )
+
+    if "z" not in heights:
+        raise RuntimeError(
+            '"z" heights must be provided to read_obst_rectangles in the heights dictionary'
+        )
+
+    x_radius = size["x"] / 2.0
+    y_radius = size["y"] / 2.0
+
+    nml = f90nml.read(file_path)
+
+    rects: list[dict[str, tuple[float, float] | float]] = []
+
+    for base in heights["z"]:
+        top = base + size["z"]
+
+        for key, val in nml.items():
+            if "obst" in key:
+                coords = val["xb"]
+
+                if base < coords[5] and top > coords[4]:
+                    rects.append(
+                        {
+                            "x": (coords[0] - x_radius, coords[1] + x_radius),
+                            "y": (coords[2] - y_radius, coords[3] + y_radius),
+                            "z": base,
+                        }
+                    )
+
+    return rects
+
+
+def read_floor_rectangles(
+    file_path: str, heights: dict[str, list[float]]
+) -> list[dict[str, tuple[float, float] | float]]:
+    """Read all the floor rectangles from a specified set of heights in an FDS file.
+
+    This determines which areas correspond exactly to floor surfaces at the specified
+    levels. The inputs are the path and the heights of the floors to investigate.
+    This returns a dictionary containing the size and positions of all of
+    the rectangles found at those floor heights.
+
+    Parameters
+    ----------
+    file_path : str
+        Path to the FDS input file.
+
+    heights : dict[str, list[float]]
+        The floor levels to investigate.
+        Must contain key "z" with a list of heights.
+
+    Returns
+    -------
+    list[dict[str, tuple[float, float] | float]]
+        Rectangles representing floor regions at the requested heights.
+        Each item has the form::
+
+            {
+                "x": (x_min, x_max),
+                "y": (y_min, y_max),
+                "z": base_elevation,
+            }
+
+    Raises
+    ------
+    RuntimeError
+        Raised if heights does not contain "z".
+
+    Notes
+    -----
+    - Only OBST lines in the input file are considered, and XB values are used to determine sizes
+    - A rectangle is only returned when the top of the obstacle lies exactly at
+      the requested floor height
+    - The returned footprints use the FDS XB x/y bounds directly, with no padding
+      or offset applied
+
+    Examples
+    --------
+    Read floor rectangles from two levels in an FDS file::
+
+        rects = read_floor_rectangles(
+            "case.fds",
+            heights={"z": [0.0, 3.0]},
+        )
+
+    A returned entry has the form::
+
+        {
+            "x": (0.0, 8.0),
+            "y": (0.0, 6.0),
+            "z": 3.0,
+        }
+
+    """
+    if "z" not in heights:
+        raise RuntimeError(
+            '"z" heights must be provided to read_floor_rectangles in the heights dictionary'
+        )
+
+    nml = f90nml.read(file_path)
+
+    rects: list[dict[str, tuple[float, float] | float]] = []
+
+    for base in heights["z"]:
+        for key, val in nml.items():
+            if "obst" in key:
+                coords = val["xb"]
+
+                if base == coords[5]:
+                    rects.append(
+                        {
+                            "x": (coords[0], coords[1]),
+                            "y": (coords[2], coords[3]),
+                            "z": base,
+                        }
+                    )
+
+    return rects

--- a/simvue_fds/helpers.py
+++ b/simvue_fds/helpers.py
@@ -4,7 +4,7 @@ import f90nml
 
 
 def read_obst_rectangles(
-    file_path: str, size: dict[str, float], heights: dict[str, list[float]]
+    file_path: str, size: dict[str, float], heights: list[float]
 ) -> list[dict[str, tuple[float, float] | float]]:
     """Read all the obstacles from a specified horizontal region in an FDS file.
 
@@ -26,9 +26,8 @@ def read_obst_rectangles(
         - "y" : horizontal total width in the y-direction
         - "z" : vertical height  in the z-direction
 
-    heights : dict[str, list[float]]
-        The floor levels to investigate.
-        Must contain key "z" with a list of heights.
+    heights : list[float]
+        The floor levels to investigate. A list of heights.
 
     Returns
     -------
@@ -50,7 +49,6 @@ def read_obst_rectangles(
     ------
     RuntimeError
         Raised if any required size key ("x", "y", or "z") is
-        missing, or if heights does not contain "z".
 
     Notes
     -----
@@ -67,7 +65,7 @@ def read_obst_rectangles(
         rects = read_obst_rectangles(
             "case.fds",
             size={"x": 0.2, "y": 0.2, "z": 3.0},
-            heights={"z": [0.0, 3.0]},
+            heights=[0.0, 3.0],
         )
 
     A returned entry has the form::
@@ -92,11 +90,6 @@ def read_obst_rectangles(
             '"z" height must be provided to read_obst_rectangles in the size dictionary'
         )
 
-    if "z" not in heights:
-        raise RuntimeError(
-            '"z" heights must be provided to read_obst_rectangles in the heights dictionary'
-        )
-
     x_radius = size["x"] / 2.0
     y_radius = size["y"] / 2.0
 
@@ -104,7 +97,7 @@ def read_obst_rectangles(
 
     rects: list[dict[str, tuple[float, float] | float]] = []
 
-    for base in heights["z"]:
+    for base in heights:
         top = base + size["z"]
 
         for key, val in nml.items():
@@ -124,7 +117,7 @@ def read_obst_rectangles(
 
 
 def read_floor_rectangles(
-    file_path: str, heights: dict[str, list[float]]
+    file_path: str, heights: list[float]
 ) -> list[dict[str, tuple[float, float] | float]]:
     """Read all the floor rectangles from a specified set of heights in an FDS file.
 
@@ -138,9 +131,8 @@ def read_floor_rectangles(
     file_path : str
         Path to the FDS input file.
 
-    heights : dict[str, list[float]]
-        The floor levels to investigate.
-        Must contain key "z" with a list of heights.
+    heights : list[float]
+        The floor levels to investigate. A list of heights.
 
     Returns
     -------
@@ -153,11 +145,6 @@ def read_floor_rectangles(
                 "y": (y_min, y_max),
                 "z": base_elevation,
             }
-
-    Raises
-    ------
-    RuntimeError
-        Raised if heights does not contain "z".
 
     Notes
     -----
@@ -185,16 +172,11 @@ def read_floor_rectangles(
         }
 
     """
-    if "z" not in heights:
-        raise RuntimeError(
-            '"z" heights must be provided to read_floor_rectangles in the heights dictionary'
-        )
-
     nml = f90nml.read(file_path)
 
     rects: list[dict[str, tuple[float, float] | float]] = []
 
-    for base in heights["z"]:
+    for base in heights:
         for key, val in nml.items():
             if "obst" in key:
                 coords = val["xb"]


### PR DESCRIPTION
# New Connector Feature - Rectangle extractor helper functions

## Description of Feature
Two new functions `read_obst_rectangles` and `read_floor_rectangles`, for users to extract information from their FDS input files. Primarily useful for constraining search spaces when investigating possible fire positions.

## Testing Performed
- **Tested Operating System(s)**: Ubuntu 25.10
- **Tested Python Version(s)**: 3.13.7

## Checklist
- [x] Code corresponds to the guidelines set out in the Contributing.md document
- [x] Any new Python package requirements have been added as an Extra to the `pyproject.toml`
- [x] ~~Unit tests have been added which check all functionality of the new feature, using Mock functions to replicate the simulation software~~ Tests to be added in a later MR
- [x] All unit tests run and pass locally
- [x] Integration tests have been updated to use the new feature and are passing in the CI
- [x] Code passes all pre-commit hooks
- [x] ~~The `Integrations` and `Examples` pages of the documentation have been updated to include information about your new feature (if applicable)~~ later
- [x] ~~Example scripts have been updated to include your new feature~~ later
