### PR TITLE
Estimate time remining for a simulation

### DIFF
--- a/simvue_fds/connector.py
+++ b/simvue_fds/connector.py
@@ -498,9 +498,9 @@ class FDSRun(WrappedRun):
         with open(input_file) as in_f:
             _file_lines = in_f.readlines()
 
-        # If loading historic runs, no point looking through entire .out file - just look at first 20 lines:
+        # If loading historic runs, no point looking through entire .out file - just look at first 100 lines:
         if self._loading_historic_run:
-            _file_lines = _file_lines[:20]
+            _file_lines = _file_lines[:100]
 
         _components_regex: dict[str, typing.Pattern[typing.AnyStr]] = {
             "revision": re.compile(r"^\s*Revision\s+\:\s*([\w\d\.\-\_][^\n]+)"),
@@ -1285,6 +1285,9 @@ class FDSRun(WrappedRun):
             _meta, _data = self._header_metadata(
                 input_file=f"{self._results_prefix}.out"
             )
+            import pdb
+
+            pdb.set_trace()
             self._header_callback(data=_data)
 
             with open(f"{self._results_prefix}.out", "r") as log_file:

--- a/simvue_fds/connector.py
+++ b/simvue_fds/connector.py
@@ -1285,9 +1285,7 @@ class FDSRun(WrappedRun):
             _meta, _data = self._header_metadata(
                 input_file=f"{self._results_prefix}.out"
             )
-            import pdb
 
-            pdb.set_trace()
             self._header_callback(data=_data)
 
             with open(f"{self._results_prefix}.out", "r") as log_file:

--- a/simvue_fds/connector.py
+++ b/simvue_fds/connector.py
@@ -398,8 +398,8 @@ class FDSRun(WrappedRun):
                         else:
                             # Estimate how long is left of the simulation
                             if (
-                                self._start_time is not None
-                                and self._end_time is not None
+                                self._fds_start_time is not None
+                                and self._fds_end_time is not None
                             ):
                                 # Record seconds elapsed
                                 time_taken = (
@@ -413,8 +413,8 @@ class FDSRun(WrappedRun):
 
                                 # Find what fraction through the simulation we are
                                 fraction_completed = (
-                                    float(_out_record["time"]) - self._start_time
-                                ) / (self._end_time - self._start_time)
+                                    float(_out_record["time"]) - self._fds_start_time
+                                ) / (self._fds_end_time - self._fds_start_time)
 
                                 # Estimate time remaining, assuming roughly constant rate of solve
                                 total_time = time_taken / fraction_completed
@@ -534,10 +534,10 @@ class FDSRun(WrappedRun):
 
     def _header_callback(self, data: dict, *_) -> None:
         start_time = data.pop("start_time", None)
-        self._start_time = float(start_time) if start_time is not None else None
+        self._fds_start_time = float(start_time) if start_time is not None else None
 
         end_time = data.pop("end_time", None)
-        self._end_time = float(end_time) if end_time is not None else None
+        self._fds_end_time = float(end_time) if end_time is not None else None
 
         self.update_metadata({"fds": data})
 
@@ -849,8 +849,8 @@ class FDSRun(WrappedRun):
         self._timestamp_mapping: numpy.ndarray = numpy.empty((0, 2))
         self._input_dict: dict = {}
         self._line_var_coords: dict | None = None
-        self._start_time: float | None = None
-        self._end_time: float | None = None
+        self._fds_start_time: float | None = None
+        self._fds_end_time: float | None = None
         self._simulation_start_time: float = datetime.now().timestamp()
 
         # Need this so that we dont get spammed with non-critical timestamp warning from fdsreader
@@ -1283,10 +1283,10 @@ class FDSRun(WrappedRun):
 
         # Extract metadata and metrics from log (.out) file
         if pathlib.Path(f"{self._results_prefix}.out").exists():
-            _data, _meta = self._header_metadata(
+            _meta, _data = self._header_metadata(
                 input_file=f"{self._results_prefix}.out"
             )
-            self.update_metadata({**_data, **_meta})
+            self._header_callback(data=_data)
 
             with open(f"{self._results_prefix}.out", "r") as log_file:
                 _, _log_metrics = self._log_parser(file_content=log_file.read())

--- a/simvue_fds/connector.py
+++ b/simvue_fds/connector.py
@@ -395,34 +395,33 @@ class FDSRun(WrappedRun):
                                     ],
                                 )
                             )
-                        else:
+                        elif (
+                            self._fds_start_time is not None
+                            and self._fds_end_time is not None
+                        ):
                             # Estimate how long is left of the simulation
-                            if (
-                                self._fds_start_time is not None
-                                and self._fds_end_time is not None
-                            ):
-                                # Record seconds elapsed
-                                time_taken = (
-                                    datetime.now().timestamp()
-                                    - self._simulation_start_time
-                                )
 
-                                # Only estimate if we are some fraction into the simulation to avoid jittery estimates early on
-                                if int(_out_record["step"]) < 100 or time_taken < 60:
-                                    continue
+                            # Record seconds elapsed
+                            time_taken = (
+                                datetime.now().timestamp() - self._simulation_start_time
+                            )
 
-                                # Find what fraction through the simulation we are
-                                fraction_completed = (
-                                    float(_out_record["time"]) - self._fds_start_time
-                                ) / (self._fds_end_time - self._fds_start_time)
+                            # Only estimate if we are some fraction into the simulation to avoid jittery estimates early on
+                            if int(_out_record["step"]) < 100 or time_taken < 60:
+                                continue
 
-                                # Estimate time remaining, assuming roughly constant rate of solve
-                                total_time = time_taken / fraction_completed
-                                time_remaining = int(total_time - time_taken)
+                            # Find what fraction through the simulation we are
+                            fraction_completed = (
+                                float(_out_record["time"]) - self._fds_start_time
+                            ) / (self._fds_end_time - self._fds_start_time)
 
-                                self.log_event(
-                                    f"Estimated time remaining: {str(timedelta(seconds=time_remaining))}"
-                                )
+                            # Estimate time remaining, assuming roughly constant rate of solve
+                            total_time = time_taken / fraction_completed
+                            time_remaining = int(total_time - time_taken)
+
+                            self.log_event(
+                                f"Estimated time remaining: {str(timedelta(seconds=time_remaining))}"
+                            )
 
                     break
 

--- a/simvue_fds/connector.py
+++ b/simvue_fds/connector.py
@@ -3,6 +3,7 @@
 This module provides functionality for using Simvue to track and monitor an FDS (Fire Dynamics Simulator) simulation.
 """
 
+import contextlib
 import csv
 import glob
 import os
@@ -14,8 +15,7 @@ import shutil
 import subprocess
 import threading
 import typing
-import contextlib
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pandas
 
@@ -395,6 +395,34 @@ class FDSRun(WrappedRun):
                                     ],
                                 )
                             )
+                        else:
+                            # Estimate how long is left of the simulation
+                            if (
+                                self._start_time is not None
+                                and self._end_time is not None
+                            ):
+                                # Record seconds elapsed
+                                time_taken = (
+                                    datetime.now().timestamp()
+                                    - self._simulation_start_time
+                                )
+
+                                # Only estimate if we are some fraction into the simulation to avoid jittery estimates early on
+                                if int(_out_record["step"]) < 100 or time_taken < 60:
+                                    continue
+
+                                # Find what fraction through the simulation we are
+                                fraction_completed = (
+                                    float(_out_record["time"]) - self._start_time
+                                ) / (self._end_time - self._start_time)
+
+                                # Estimate time remaining, assuming roughly constant rate of solve
+                                total_time = time_taken / fraction_completed
+                                time_remaining = int(total_time - time_taken)
+
+                                self.log_event(
+                                    f"Estimated time remaining: {str(timedelta(seconds=time_remaining))}"
+                                )
 
                     break
 
@@ -491,16 +519,27 @@ class FDSRun(WrappedRun):
             "mpi_library_version": re.compile(
                 r"^\s*MPI library version:\s*([\w\d\.\s\*\(\)\[\]\-\_][^\n]+)"
             ),
+            "start_time": re.compile(r"^\s*Simulation Start Time \(s\)\s*([\d\.]+)"),
+            "end_time": re.compile(r"^\s*Simulation End Time \(s\)\s*([\d\.]+)"),
         }
 
-        _output_metadata: dict[str, str] = {"fds": {}}
+        _output_metadata: dict[str, str] = {}
 
         for line in _file_lines:
             for key, regex in _components_regex.items():
                 if search_res := regex.findall(line):
-                    _output_metadata["fds"][key] = search_res[0]
+                    _output_metadata[key] = search_res[0]
 
         return {}, _output_metadata
+
+    def _header_callback(self, data: dict, *_) -> None:
+        start_time = data.pop("start_time", None)
+        self._start_time = float(start_time) if start_time is not None else None
+
+        end_time = data.pop("end_time", None)
+        self._end_time = float(end_time) if end_time is not None else None
+
+        self.update_metadata({"fds": data})
 
     def _ctrl_log_callback(self, data: dict, *_) -> None:
         """Log metrics extracted from the CTRL log file to Simvue.
@@ -810,6 +849,9 @@ class FDSRun(WrappedRun):
         self._timestamp_mapping: numpy.ndarray = numpy.empty((0, 2))
         self._input_dict: dict = {}
         self._line_var_coords: dict | None = None
+        self._start_time: float | None = None
+        self._end_time: float | None = None
+        self._simulation_start_time: float = datetime.now().timestamp()
 
         # Need this so that we dont get spammed with non-critical timestamp warning from fdsreader
         fdsreader.settings.IGNORE_ERRORS = True
@@ -893,6 +935,7 @@ class FDSRun(WrappedRun):
             cwd=self.workdir_path,
             completion_callback=check_for_errors,
         )
+        self._simulation_start_time = datetime.now().timestamp()
 
         if self.slice_parse_enabled:
             self.slice_parser = threading.Thread(
@@ -916,7 +959,7 @@ class FDSRun(WrappedRun):
         self.file_monitor.track(
             path_glob_exprs=f"{self._results_prefix}.out",
             parser_func=mp_file_parser.file_parser(self._header_metadata),
-            callback=lambda data, meta: self.update_metadata({**data, **meta}),
+            callback=self._header_callback,
             static=True,
         )
         # Track line.csv file, can be entirely overwritten on each time step

--- a/tests/unit/test_fds_header_parser.py
+++ b/tests/unit/test_fds_header_parser.py
@@ -19,7 +19,7 @@ def mock_fds_process(self, *_, **__):
     def create_header(self):
         shutil.copy(
             pathlib.Path(__file__).parent.joinpath("example_data", "fds_header.txt"),
-            pathlib.Path(self.workdir_path).joinpath(f"fds_test.out"),
+            pathlib.Path(self.workdir_path).joinpath("fds_test.out"),
         )
         time.sleep(1)
         self._trigger.set()

--- a/tests/unit/test_fds_header_parser.py
+++ b/tests/unit/test_fds_header_parser.py
@@ -9,50 +9,78 @@ import threading
 from unittest.mock import patch
 import pytest
 import shutil
+
+
 def mock_fds_process(self, *_, **__):
     """
     Mock process for writing FDS log header, all at once.
     """
+
     def create_header(self):
-        shutil.copy(pathlib.Path(__file__).parent.joinpath("example_data", "fds_header.txt"), pathlib.Path(self.workdir_path).joinpath(f"fds_test.out"))
+        shutil.copy(
+            pathlib.Path(__file__).parent.joinpath("example_data", "fds_header.txt"),
+            pathlib.Path(self.workdir_path).joinpath(f"fds_test.out"),
+        )
         time.sleep(1)
         self._trigger.set()
         return
+
     thread = threading.Thread(target=create_header, args=(self,))
     thread.start()
-    
+
+
 @pytest.mark.parametrize("load", (True, False), ids=("load", "launch"))
-@patch.object(FDSRun, '_find_fds_executable', lambda _: None)  
-@patch.object(FDSRun, 'add_process', mock_fds_process)
+@patch.object(FDSRun, "_find_fds_executable", lambda _: None)
+@patch.object(FDSRun, "add_process", mock_fds_process)
 def test_fds_header_parser(folder_setup, load):
     """
     Check that metadata from the header of the log file is correctly uploaded.
     """
-    name = 'test_fds_header_parser-%s' % str(uuid.uuid4())
+    name = "test_fds_header_parser-%s" % str(uuid.uuid4())
     temp_dir = tempfile.TemporaryDirectory(prefix="fds_test")
     with FDSRun() as run:
         run.config(disable_resources_metrics=True)
         run.init(name=name, folder=folder_setup)
         run_id = run.id
         if load:
-            shutil.copy(pathlib.Path(__file__).parent.joinpath("example_data", "fds_input.fds"), pathlib.Path(temp_dir.name).joinpath("fds_input.fds"))
-            shutil.copy(pathlib.Path(__file__).parent.joinpath("example_data", "fds_header.txt"), pathlib.Path(temp_dir.name).joinpath("fds_test.out"))
+            shutil.copy(
+                pathlib.Path(__file__).parent.joinpath("example_data", "fds_input.fds"),
+                pathlib.Path(temp_dir.name).joinpath("fds_input.fds"),
+            )
+            shutil.copy(
+                pathlib.Path(__file__).parent.joinpath(
+                    "example_data", "fds_header.txt"
+                ),
+                pathlib.Path(temp_dir.name).joinpath("fds_test.out"),
+            )
             run.load(
-                results_dir = temp_dir.name,
+                results_dir=temp_dir.name,
             )
         else:
             run.launch(
-                fds_input_file_path = pathlib.Path(__file__).parent.joinpath("example_data", "fds_input.fds"),
-                workdir_path = temp_dir.name,
+                fds_input_file_path=pathlib.Path(__file__).parent.joinpath(
+                    "example_data", "fds_input.fds"
+                ),
+                workdir_path=temp_dir.name,
             )
-        
+
+        # Check start and end times parsed
+        assert run._fds_start_time == 0
+        assert run._fds_end_time == 5
+
     client = simvue.Client()
-    
+
     run_data = client.get_run(run_id).metadata
-    assert run_data["fds"]["revision"] == "FDS-6.9.1-0-g889da6a-release"        
+    assert run_data["fds"]["revision"] == "FDS-6.9.1-0-g889da6a-release"
     assert run_data["fds"]["revision_date"] == "Sun Apr 7 17:05:06 2024 -0400"
-    assert run_data["fds"]["compiler"] == "Intel(R) Fortran Intel(R) 64 Compiler Classic for applications running on Intel(R) 64, Version 2021.7.1 Build 20221019_000000"
+    assert (
+        run_data["fds"]["compiler"]
+        == "Intel(R) Fortran Intel(R) 64 Compiler Classic for applications running on Intel(R) 64, Version 2021.7.1 Build 20221019_000000"
+    )
     assert run_data["fds"]["compilation_date"] == "Apr 09, 2024 13:24:51"
-    assert run_data["fds"]["mpi_processes"] == '1'
-    assert run_data["fds"]["mpi_version"] == '3.1'
-    assert run_data["fds"]["mpi_library_version"] == "Intel(R) MPI Library 2021.6 for Linux* OS"
+    assert run_data["fds"]["mpi_processes"] == "1"
+    assert run_data["fds"]["mpi_version"] == "3.1"
+    assert (
+        run_data["fds"]["mpi_library_version"]
+        == "Intel(R) MPI Library 2021.6 for Linux* OS"
+    )


### PR DESCRIPTION
# New Connector Feature - Estimate remaining time

## Description of Feature
Estimates the time remaining for a simulation based on how long a simulation has been running so far, and how far through the simulation we are.

## Testing Performed
- **Tested Software Version(s)**: FDS 6.9.1
- **Tested Operating System(s)**: Ubuntu 24.04
- **Tested Python Version(s)**: 3.12
- **Tested Simvue Python API Version(s)**: 2.4.0

## Documentation
- **Link to Documentation PR**: Not needed
## Links to Issues
Closes #58 

## Comments
Requested by multiple users

## Checklist
- [x] Code corresponds to the guidelines set out in the Contributing.md document
- [ ] ~Any new Python package requirements have been added as an Extra to the `pyproject.toml`~
- [x] Unit tests have been added which check all functionality of the new feature, using Mock functions to replicate the simulation software
- [x] All unit tests run and pass locally
- [ ] ~Integration tests have been updated to use the new feature and are passing in the CI~ (integration tests cant be updated as they need at least 1 min to estimate time remaining)
- [x] Code passes all pre-commit hooks
- [ ] ~The `Integrations` and `Examples` pages of the documentation have been updated to include information about your new feature (if applicable)~
- [ ] ~Example scripts have been updated to include your new feature~
