### PR TITLE
Slice Colorbars and NaNs

### DIFF
--- a/simvue_fds/connector.py
+++ b/simvue_fds/connector.py
@@ -787,6 +787,19 @@ class FDSRun(WrappedRun):
                 )
                 self._grids_defined.append(metric_name)
 
+                # Record the colorbar this slice should use:
+                self.update_metadata(
+                    {
+                        "simvue": {
+                            "plots": {
+                                metric_name: "Rainbow (inverse)"
+                                if "visibility" in slice.quantity.quantity.lower()
+                                else "Rainbow"
+                            }
+                        }
+                    }
+                )
+
             if metric_name not in self._grids_defined:
                 continue
 
@@ -946,7 +959,7 @@ class FDSRun(WrappedRun):
 
         if run_command := os.getenv("SIMVUE_FDS_RUN_COMMAND"):
             logger.warning(
-                "Custom FDS run command provided - environment variables passed into launch will be ignored."
+                "Custom FDS run command provided - parallel settings and environment variables passed into launch will be ignored."
             )
             command: list = shlex.split(
                 run_command, posix=platform.system() == "Windows"

--- a/simvue_fds/connector.py
+++ b/simvue_fds/connector.py
@@ -816,7 +816,7 @@ class FDSRun(WrappedRun):
 
                 self.log_metrics(
                     {
-                        metric_name: numpy.nan_to_num(values_at_time).T,
+                        metric_name: values_at_time.T,
                         f"{metric_name}.min": numpy.min(values_no_obst),
                         f"{metric_name}.max": numpy.max(values_no_obst),
                         f"{metric_name}.avg": numpy.mean(values_no_obst),

--- a/simvue_fds/connector.py
+++ b/simvue_fds/connector.py
@@ -792,9 +792,11 @@ class FDSRun(WrappedRun):
                     {
                         "simvue": {
                             "plots": {
-                                metric_name: "Rainbow (inverse)"
-                                if "visibility" in slice.quantity.quantity.lower()
-                                else "Rainbow"
+                                metric_name: {
+                                    "colourscale": "Rainbow (inverse)"
+                                    if "visibility" in slice.quantity.quantity.lower()
+                                    else "Rainbow"
+                                }
                             }
                         }
                     }

--- a/tests/integration/test_fds.py
+++ b/tests/integration/test_fds.py
@@ -125,7 +125,7 @@ def test_fds_supply_exhaust(folder_setup, offline_cache_setup, load, offline, pa
             parallel=parallel,
             offline=offline,
             slice_var=None,
-            slice_fixed_dim="z",
+            slice_fixed_dim=["y", "z"],
             load=load,
         )
     except Exception as e:
@@ -160,6 +160,17 @@ def test_fds_supply_exhaust(folder_setup, offline_cache_setup, load, offline, pa
     # Check metadata from input file
     assert run_data.metadata["input_file"]["_grp_devc_1"]["id"] == "flow_volume_supply"
 
+    # Check metadata for slice colorbars uploaded
+    # Temperature should use Rainbow
+    assert (
+        run_data.metadata["simvue"]["plots"]["temperature.y.2_0"]["colourscale"]
+        == "Rainbow"
+    )
+    # Visibility should use Rainbow (Inverse)
+    assert (
+        run_data.metadata["simvue"]["plots"]["soot_visibility.z.2_0"]["colourscale"]
+        == "Rainbow (inverse)"
+    )
     # Check events from log, check negative time upladed
     # Loosening requirement for this since Windows and Ubuntu will print slightly different times
     assert any(
@@ -187,16 +198,16 @@ def test_fds_supply_exhaust(folder_setup, offline_cache_setup, load, offline, pa
     assert metrics["max_divergence.mesh.2"]["count"] > 0
 
     # Check metrics from slice
-    assert metrics["soot_visibility.z.2_0.min"]["count"] > 0
-    assert metrics["soot_visibility.z.2_0.min"]["count"] > 0
-    assert metrics["soot_visibility.z.2_0.min"]["count"] > 0
+    assert metrics["temperature.y.2_0.min"]["count"] > 0
+    assert metrics["temperature.y.2_0.min"]["count"] > 0
+    assert metrics["temperature.y.2_0.min"]["count"] > 0
 
     # Check metrics from each possible type of file have a negative first time point
     for metric in (
         "HRR",
         "flow_volume_supply",
         "max_pressure_error",
-        "soot_visibility.z.2_0.min",
+        "temperature.y.2_0.min",
     ):
         _retrieved = client.get_metric_values(
             run_ids=[run_id],
@@ -208,30 +219,25 @@ def test_fds_supply_exhaust(folder_setup, offline_cache_setup, load, offline, pa
     _retrieved = client.get_metric_values(
         run_ids=[run_id],
         metric_names=[
-            "soot_visibility.z.2_0.max",
-            "soot_visibility.z.2_0.min",
-            "soot_visibility.z.2_0.avg",
+            "temperature.y.2_0.max",
+            "temperature.y.2_0.min",
+            "temperature.y.2_0.avg",
         ],
         xaxis="time",
     )
-    _max = numpy.array(list(_retrieved["soot_visibility.z.2_0.max"].values()))
-    _min = numpy.array(list(_retrieved["soot_visibility.z.2_0.min"].values()))
-    _avg = numpy.array(list(_retrieved["soot_visibility.z.2_0.avg"].values()))
+    _max = numpy.array(list(_retrieved["temperature.y.2_0.max"].values()))
+    _min = numpy.array(list(_retrieved["temperature.y.2_0.min"].values()))
+    _avg = numpy.array(list(_retrieved["temperature.y.2_0.avg"].values()))
 
     # Check all max >= avg >= min
     assert numpy.all(_max >= _avg)
     assert numpy.all(_avg >= _min)
     assert numpy.all(_min > 0)
 
-    # From smokeview, min = 20, max = 574.316
-    # Check our calculations are within 0.1 of this
-    # numpy.testing.assert_allclose(_max.max(), 574.316, atol=0.1)
-    # numpy.testing.assert_allclose(_min.min(), 20.0, atol=0.1)
-
     # Check slice uploaded as 3D metric
     _user_config: SimvueConfiguration = SimvueConfiguration.fetch(mode="online")
     response = requests.get(
-        url=f"{_user_config.server.url}/runs/{run_id}/metrics/soot_visibility.z.2_0/values?step=0",
+        url=f"{_user_config.server.url}/runs/{run_id}/metrics/temperature.y.2_0/values?step=0",
         headers={
             "Authorization": f"Bearer {_user_config.server.token.get_secret_value()}",
             "User-Agent": "Simvue Python client",
@@ -239,7 +245,12 @@ def test_fds_supply_exhaust(folder_setup, offline_cache_setup, load, offline, pa
         },
     )
     assert response.status_code == 200
-    numpy.array(response.json().get("array")).shape == (41, 31)
+    arr = numpy.array(response.json().get("array"))
+    assert arr.shape == (31, 31)
+
+    # Check fire obstructions uploaded as NaNs (come back as None's over API)
+    # Obstruction is on the floor (z=0) from x=1.3 to x=1.7
+    assert all(arr[0, 13:17] == None)
 
     # Check line DEVC uploaded as 2D metric
     _user_config: SimvueConfiguration = SimvueConfiguration.fetch(mode="online")
@@ -402,6 +413,13 @@ def test_fds_bre_spray(folder_setup, offline_cache_setup, offline, parallel, loa
     # Check metadata from input file NOT uploaded
     assert not run_data.metadata.get("input_file")
 
+    # Check metadata for slice colorbars uploaded
+    # Temperature should use Rainbow
+    assert (
+        run_data.metadata["simvue"]["plots"]["temperature.y.0_0"]["colourscale"]
+        == "Rainbow"
+    )
+
     # Check events from log
     assert any(
         [event.startswith("Time Step: 1, Simulation Time: 0.05") for event in events]
@@ -534,6 +552,13 @@ def test_fds_pohlhausen(folder_setup, offline_cache_setup, offline, parallel, lo
 
     # Check metadata from input file
     assert run_data.metadata["input_file"]["_grp_devc_0"]["id"] == "T_out"
+
+    # Check metadata for slice colorbars uploaded
+    # Temperature should use Rainbow
+    assert (
+        run_data.metadata["simvue"]["plots"]["temperature.y.0_1"]["colourscale"]
+        == "Rainbow"
+    )
 
     # Check events from log
     assert any(

--- a/tests/integration/test_fds.py
+++ b/tests/integration/test_fds.py
@@ -66,7 +66,7 @@ def run_fds(
                     results_dir=file_path,
                     slice_parse_enabled=True if slice_var or slice_fixed_dim else False,
                     slice_parse_quantities=[slice_var] if slice_var else None,
-                    slice_parse_fixed_dimensions=[slice_fixed_dim]
+                    slice_parse_fixed_dimensions=slice_fixed_dim
                     if slice_fixed_dim
                     else None,
                     upload_input_metadata=upload_input_metadata,
@@ -80,7 +80,7 @@ def run_fds(
                     # You can optionally have the connector track slices in your simulation
                     slice_parse_enabled=True if slice_var or slice_fixed_dim else False,
                     slice_parse_quantities=[slice_var] if slice_var else None,
-                    slice_parse_fixed_dimensions=[slice_fixed_dim]
+                    slice_parse_fixed_dimensions=slice_fixed_dim
                     if slice_fixed_dim
                     else None,
                     slice_parse_interval=10,

--- a/tests/unit/test_fds_slice_parser.py
+++ b/tests/unit/test_fds_slice_parser.py
@@ -132,12 +132,20 @@ def test_fds_slice_parser(
     client = simvue.Client()
 
     metrics_names = [item for item in client.get_metrics_names(run_id)]
+    run_metadata = client.get_run(run_id).metadata
 
     if not expected_slices:
         assert not metrics_names
     else:
         # Check at least 6 times recorded (since we stopped the sim at ~5s)
         for metric, slice_dims in expected_slices.items():
+            # Check colorbar information uploaded
+            assert (
+                run_metadata["simvue"]["plots"][metric].get("colourscale")
+                == "Rainbow (inverse)"
+                if "soot_visibility" in metric
+                else "Rainbow"
+            )
             assert metric + ".max" in metrics_names
             assert metric + ".min" in metrics_names
             assert metric + ".avg" in metrics_names


### PR DESCRIPTION
# New Connector Feature

## Description of Feature
Adds colorbar metadata for slices, and uploads OBSTs as NaNs.

## Testing Performed
- **Tested Software Version(s)**: FDS 6.10.1
- **Tested Operating System(s)**: Ubuntu 24.04
- **Tested Python Version(s)**: 3.12
- **Tested Simvue Python API Version(s)**: 2.4.1

## Checklist
- [x] Code corresponds to the guidelines set out in the Contributing.md document
- [ ] ~Any new Python package requirements have been added as an Extra to the `pyproject.toml`~
- [x] Unit tests have been added which check all functionality of the new feature, using Mock functions to replicate the simulation software
- [x] All unit tests run and pass locally
- [x] Integration tests have been updated to use the new feature and are passing in the CI
- [x] Code passes all pre-commit hooks
- [ ] ~The `Integrations` and `Examples` pages of the documentation have been updated to include information about your new feature (if applicable)~
- [ ] ~Example scripts have been updated to include your new feature~
