### PR TITLE
Add tests of helper functions

### DIFF
--- a/simvue_fds/helpers.py
+++ b/simvue_fds/helpers.py
@@ -4,14 +4,16 @@ import f90nml
 
 
 def read_obst_rectangles(
-    file_path: str, size: dict[str, float], heights: list[float]
+    file_path: str,
+    size: dict[str, float],
+    heights: list[float],
 ) -> list[dict[str, tuple[float, float] | float]]:
     """Read all the obstacles from a specified horizontal region in an FDS file.
 
-    This determines which areas are 'blocked' from containing an item of a specified size.
-    The inputs are the path, the size of the object, and the heights of the floors to investigate.
-    This returns a dictionary containing the size and positions of all of
-    the rectangles that must be avoided along with their heights.
+    This determines which areas are blocked from containing an item of a specified
+    size. The inputs are the path, the size of the object, and the heights of the
+    floors to investigate. This returns a list containing the positions and sizes
+    of all rectangles that must be avoided, along with their base heights.
 
     Parameters
     ----------
@@ -19,21 +21,21 @@ def read_obst_rectangles(
         Path to the FDS input file.
 
     size : dict[str, float]
-        The 3 dimensional size/footprint of the object
+        The 3-dimensional size/footprint of the object.
 
         Required keys are:
-        - "x" : horizontal width in the x-direction
-        - "y" : horizontal total width in the y-direction
-        - "z" : vertical height  in the z-direction
+        - ``"x"`` : horizontal width in the x-direction
+        - ``"y"`` : horizontal total width in the y-direction
+        - ``"z"`` : vertical height in the z-direction
 
     heights : list[float]
-        The floor levels to investigate. A list of heights.
+        The floor levels to investigate.
 
     Returns
     -------
     list[dict[str, tuple[float, float] | float]]
-        Rectangles representing regions in which the centre of the object cannot be located
-        Each item has the form::
+        Rectangles representing regions in which the centre of the object cannot
+        be located. Each item has the form::
 
             {
                 "x": (x_min, x_max),
@@ -48,14 +50,16 @@ def read_obst_rectangles(
     Raises
     ------
     RuntimeError
-        Raised if any required size key ("x", "y", or "z") is
+        Raised if any required size key (``"x"``, ``"y"``, or ``"z"``) is missing
+        from the ``size`` dictionary.
 
     Notes
     -----
-    - Only OBST lines in the input file are considered, and XB values are used to determine sizes
+    - Only ``OBST`` entries in the input file are considered, and ``XB`` values
+      are used to determine sizes.
     - Vertical intersection is tested using strict inequalities, so an obstacle
-      whose bottom just touches the top of the object you're trying to place is not included
-    - The returned footprints use the FDS XB x/y bounds, then pads them by half
+      whose bottom just touches the top of the object being placed is not included.
+    - The returned footprints use the FDS ``XB`` x/y bounds, then pad them by half
       the supplied object size on each side.
 
     Examples
@@ -101,7 +105,7 @@ def read_obst_rectangles(
         top = base + size["z"]
 
         for key, val in nml.items():
-            if "obst" in key:
+            if key.lower() == "obst":
                 coords = val["xb"]
 
                 if base < coords[5] and top > coords[4]:
@@ -117,14 +121,15 @@ def read_obst_rectangles(
 
 
 def read_floor_rectangles(
-    file_path: str, heights: list[float]
+    file_path: str,
+    heights: list[float],
 ) -> list[dict[str, tuple[float, float] | float]]:
     """Read all the floor rectangles from a specified set of heights in an FDS file.
 
-    This determines which areas correspond exactly to floor surfaces at the specified
-    levels. The inputs are the path and the heights of the floors to investigate.
-    This returns a dictionary containing the size and positions of all of
-    the rectangles found at those floor heights.
+    This determines which areas correspond exactly to floor surfaces at the
+    specified levels. The inputs are the path and the heights of the floors to
+    investigate. This returns a list containing the positions and sizes of all
+    rectangles found at those floor heights.
 
     Parameters
     ----------
@@ -132,7 +137,7 @@ def read_floor_rectangles(
         Path to the FDS input file.
 
     heights : list[float]
-        The floor levels to investigate. A list of heights.
+        The floor levels to investigate.
 
     Returns
     -------
@@ -148,11 +153,12 @@ def read_floor_rectangles(
 
     Notes
     -----
-    - Only OBST lines in the input file are considered, and XB values are used to determine sizes
+    - Only ``OBST`` entries in the input file are considered, and ``XB`` values
+      are used to determine sizes.
     - A rectangle is only returned when the top of the obstacle lies exactly at
-      the requested floor height
-    - The returned footprints use the FDS XB x/y bounds directly, with no padding
-      or offset applied
+      the requested floor height.
+    - The returned footprints use the FDS ``XB`` x/y bounds directly, with no
+      padding or offset applied.
 
     Examples
     --------
@@ -160,7 +166,7 @@ def read_floor_rectangles(
 
         rects = read_floor_rectangles(
             "case.fds",
-            heights={"z": [0.0, 3.0]},
+            heights=[0.0, 3.0],
         )
 
     A returned entry has the form::
@@ -178,7 +184,7 @@ def read_floor_rectangles(
 
     for base in heights:
         for key, val in nml.items():
-            if "obst" in key:
+            if key.lower() == "obst":
                 coords = val["xb"]
 
                 if base == coords[5]:

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -1,0 +1,190 @@
+import textwrap
+
+import pytest
+
+from simvue_fds import helpers
+
+
+def _write_fds(tmp_path, text: str):
+    path = tmp_path / "case.fds"
+    path.write_text(textwrap.dedent(text).strip() + "\n", encoding="utf-8")
+    return path
+
+
+@pytest.mark.parametrize(
+    ("size", "message"),
+    [
+        ({"y": 1.0, "z": 2.0}, '"x" width'),
+        ({"x": 1.0, "z": 2.0}, '"y" width'),
+        ({"x": 1.0, "y": 2.0}, '"z" height'),
+    ],
+)
+def test_read_obst_rectangles_raises_error_if_size_key_missing(size, message):
+    with pytest.raises(
+        RuntimeError,
+        match=f"{message} must be provided to read_obst_rectangles in the size dictionary",
+    ):
+        helpers.read_obst_rectangles("dummy.fds", size=size, heights=[0.0])
+
+
+def test_read_obst_rectangles_reads_matching_obstacles_and_applies_padding(tmp_path):
+    path = _write_fds(
+        tmp_path,
+        """
+        &OBST XB=1.0,3.0,10.0,14.0,0.5,2.0 /
+        &OBST XB=5.0,6.0,7.0,8.0,4.0,5.0 /
+        """,
+    )
+
+    result = helpers.read_obst_rectangles(
+        str(path),
+        size={"x": 2.0, "y": 4.0, "z": 1.0},
+        heights=[1.0],
+    )
+
+    assert result == [{"x": (0.0, 4.0), "y": (8.0, 16.0), "z": 1.0}]
+
+
+@pytest.mark.parametrize(
+    ("size_z", "obst_base", "obst_top", "expected_count"),
+    [
+        (1.0, 0.0, 3.0, 1),  # object fully inside obstacle
+        (3.0, 2.0, 3.0, 1),  # obstacle fully inside object
+        (1.0, 0.0, 1.5, 1),  # partial overlap from below
+        (1.0, 1.5, 3.0, 1),  # partial overlap from above
+        (1.0, 2.0, 3.0, 0),  # obstacle bottom touches object top
+        (1.0, 0.0, 1.0, 0),  # obstacle top touches object base
+        (1.0, 2.1, 3.0, 0),  # fully above
+        (1.0, -2.0, 0.9, 0),  # fully below
+    ],
+)
+def test_read_obst_rectangles_checks_strict_vertical_intersection(
+    tmp_path, size_z, obst_base, obst_top, expected_count
+):
+    path = _write_fds(
+        tmp_path,
+        f"""
+        &OBST XB=10.0,20.0,30.0,40.0,{obst_base},{obst_top} /
+        """,
+    )
+
+    result = helpers.read_obst_rectangles(
+        str(path),
+        size={"x": 2.0, "y": 2.0, "z": size_z},
+        heights=[1.0],
+    )
+
+    assert len(result) == expected_count
+    if expected_count:
+        assert result == [{"x": (9.0, 21.0), "y": (29.0, 41.0), "z": 1.0}]
+
+
+def test_read_obst_rectangles_returns_both_matching_obstacles_at_one_floor(tmp_path):
+    path = _write_fds(
+        tmp_path,
+        """
+        &OBST XB=0.0,1.0,0.0,1.0,0.0,2.0 /
+        &OBST XB=2.0,4.0,3.0,5.0,0.5,3.0 /
+        &OBST XB=10.0,11.0,10.0,11.0,3.0,4.0 /
+        """,
+    )
+
+    result = helpers.read_obst_rectangles(
+        str(path),
+        size={"x": 2.0, "y": 2.0, "z": 1.0},
+        heights=[1.0],
+    )
+
+    assert result == [
+        {"x": (-1.0, 2.0), "y": (-1.0, 2.0), "z": 1.0},
+        {"x": (1.0, 5.0), "y": (2.0, 6.0), "z": 1.0},
+    ]
+
+
+def test_read_obst_rectangles_returns_one_result_per_matching_height(tmp_path):
+    path = _write_fds(
+        tmp_path,
+        """
+        &OBST XB=0.0,1.0,0.0,1.0,0.0,5.0 /
+        """,
+    )
+
+    result = helpers.read_obst_rectangles(
+        str(path),
+        size={"x": 0.0, "y": 0.0, "z": 1.0},
+        heights=[0.0, 2.0, 4.5],
+    )
+
+    assert result == [
+        {"x": (0.0, 1.0), "y": (0.0, 1.0), "z": 0.0},
+        {"x": (0.0, 1.0), "y": (0.0, 1.0), "z": 2.0},
+        {"x": (0.0, 1.0), "y": (0.0, 1.0), "z": 4.5},
+    ]
+
+
+def test_read_obst_rectangles_with_empty_heights_returns_empty_list(tmp_path):
+    path = _write_fds(
+        tmp_path,
+        """
+        &OBST XB=0.0,1.0,0.0,1.0,0.0,2.0 /
+        """,
+    )
+
+    result = helpers.read_obst_rectangles(
+        str(path),
+        size={"x": 1.0, "y": 1.0, "z": 1.0},
+        heights=[],
+    )
+
+    assert result == []
+
+
+def test_read_floor_rectangles_returns_exact_matches_at_requested_heights(tmp_path):
+    path = _write_fds(
+        tmp_path,
+        """
+        &OBST XB=0.0,8.0,0.0,6.0,0.0,3.0 /
+        &OBST XB=2.0,3.0,7.0,9.0,2.0,3.0 /
+        &OBST XB=1.0,2.0,1.0,2.0,4.0,5.0 /
+        """,
+    )
+
+    result = helpers.read_floor_rectangles(str(path), heights=[3.0, 5.0, 7.0])
+
+    assert result == [
+        {"x": (0.0, 8.0), "y": (0.0, 6.0), "z": 3.0},
+        {"x": (2.0, 3.0), "y": (7.0, 9.0), "z": 3.0},
+        {"x": (1.0, 2.0), "y": (1.0, 2.0), "z": 5.0},
+    ]
+
+
+@pytest.mark.parametrize(
+    ("top", "matches"), [(3.0, True), (3.0000000001, False), (2.9999999999, False)]
+)
+def test_read_floor_rectangles_uses_exact_equality(tmp_path, top, matches):
+    path = _write_fds(
+        tmp_path,
+        f"""
+        &OBST XB=1.0,2.0,3.0,4.0,0.0,{top} /
+        """,
+    )
+
+    result = helpers.read_floor_rectangles(str(path), heights=[3.0])
+
+    if matches:
+        assert result == [{"x": (1.0, 2.0), "y": (3.0, 4.0), "z": 3.0}]
+    else:
+        assert result == []
+
+
+def test_read_floor_rectangles_with_empty_heights_returns_empty_list(tmp_path):
+    path = _write_fds(
+        tmp_path,
+        """
+        &OBST XB=0.0,2.0,0.0,2.0,0.0,3.0 /
+        """,
+    )
+
+    result = helpers.read_floor_rectangles(str(path), heights=[])
+
+    assert result == []

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -139,6 +139,33 @@ def test_read_obst_rectangles_with_empty_heights_returns_empty_list(tmp_path):
     assert result == []
 
 
+def test_read_obst_rectangles_ignores_non_obst_lines(tmp_path):
+    path = _write_fds(
+        tmp_path,
+        """
+        &HEAD CHID='test' /
+        &TIME T_END=10.0 /
+        &MESH IJK=10,10,10, XB=0.0,1.0,0.0,1.0,0.0,1.0 /
+        &VENT XB=100.0,200.0,100.0,200.0,0.0,5.0, SURF_ID='OPEN' /
+        &OBST XB=1.0,3.0,10.0,14.0,0.5,2.0 /
+        """,
+    )
+
+    result = helpers.read_obst_rectangles(
+        str(path),
+        size={"x": 2.0, "y": 4.0, "z": 1.0},
+        heights=[1.0],
+    )
+
+    assert result == [
+        {
+            "x": (0.0, 4.0),
+            "y": (8.0, 16.0),
+            "z": 1.0,
+        }
+    ]
+
+
 def test_read_floor_rectangles_returns_exact_matches_at_requested_heights(tmp_path):
     path = _write_fds(
         tmp_path,
@@ -188,3 +215,26 @@ def test_read_floor_rectangles_with_empty_heights_returns_empty_list(tmp_path):
     result = helpers.read_floor_rectangles(str(path), heights=[])
 
     assert result == []
+
+
+def test_read_floor_rectangles_ignores_non_obst_lines(tmp_path):
+    path = _write_fds(
+        tmp_path,
+        """
+        &HEAD CHID='test' /
+        &TIME T_END=10.0 /
+        &MESH IJK=10,10,10, XB=0.0,1.0,0.0,1.0,0.0,1.0 /
+        &VENT XB=100.0,200.0,100.0,200.0,0.0,3.0, SURF_ID='OPEN' /
+        &OBST XB=0.0,8.0,0.0,6.0,0.0,3.0 /
+        """,
+    )
+
+    result = helpers.read_floor_rectangles(str(path), heights=[3.0])
+
+    assert result == [
+        {
+            "x": (0.0, 8.0),
+            "y": (0.0, 6.0),
+            "z": 3.0,
+        }
+    ]


### PR DESCRIPTION
# New tests for helper rectangle-extraction functions

## Description of Tests
This adds testing for the rectangle-extraction helper functions that were recently added, and slightly tightens some checks they do.

## Testing Performed
- **Tested Operating System(s)**: Ubuntu 25.10
- **Tested Python Version(s)**: 3.12.11

## Checklist
- [x] Code corresponds to the guidelines set out in the Contributing.md document
- [x] Any new Python package requirements have been added as an Extra to the `pyproject.toml` (none)
- [x] All **new** unit tests run and pass locally
- [x] ~~Integration tests are passing in the CI~~ unchanged
- [x] Code passes all pre-commit hooks
