### PR TITLE
Heterogeneous Meshes

### DIFF
--- a/simvue_fds/connector.py
+++ b/simvue_fds/connector.py
@@ -36,7 +36,7 @@ from fdsreader.slcf.slice import Slice
 from simvue_connector.connector import WrappedRun
 from simvue_connector.extras.create_command import format_command_env_vars
 
-from simvue_fds.helpers import create_obst_mask
+from simvue_fds.helpers import create_heterogeneous_slice, create_obst_mask
 
 logger = logging.getLogger(__name__)
 MAXIMUM_SLICE_SIZE: int = 50000
@@ -728,50 +728,8 @@ class FDSRun(WrappedRun):
             # Get the values, coordinates, times
             # Due to edge cases which may break fdsreader, we cover this in a try... except
             try:
-                coords: dict[str, numpy.ndarray] = slice.get_coordinates()
                 times = slice.times
-                dims = slice.extent_dirs
-                values = numpy.zeros(
-                    (len(slice.times), len(coords[dims[0]]), len(coords[dims[1]]))
-                )
-                # Loop through subslices
-                for subslice in slice.subslices:
-                    start_idx = []
-                    end_idx = []
-                    insert_indices = []
-
-                    # Get subslice data
-                    subslice_vals: numpy.ndarray = subslice.data
-
-                    # Loop through dimensions
-                    for i, dim in enumerate(dims):
-                        # Get coords for subslice
-                        sub_coords = subslice.get_coordinates()
-                        # Find indexes in global coords where subslice coords start and end
-                        start_idx.append(
-                            numpy.where(coords[dim] == sub_coords[dim][0])[0][0]
-                        )
-                        end_idx.append(
-                            numpy.where(coords[dim] == sub_coords[dim][-1])[0][0]
-                        )
-
-                        # Cut global coords to be same start and end as subslice coords
-                        trimmed_all_coords = coords[dim][start_idx[i] : end_idx[i] + 1]
-                        # Could use searchsorted to find indexes to insert elements into to maintain order of coords
-                        insert_indices.append(
-                            numpy.searchsorted(sub_coords[dim], trimmed_all_coords)
-                        )
-
-                    # Expand subslice values using the indices which maintain order
-                    subslice_expanded = subslice_vals[
-                        :, insert_indices[0][:, None], insert_indices[1][None, :]
-                    ]
-                    # Insert into correct place in grid
-                    values[
-                        :,
-                        start_idx[0] : start_idx[0] + subslice_expanded.shape[1],
-                        start_idx[1] : start_idx[1] + subslice_expanded.shape[2],
-                    ] = subslice_expanded
+                coords, values = create_heterogeneous_slice(slice)
 
             except Exception as e:
                 if not self._grids_defined:

--- a/simvue_fds/connector.py
+++ b/simvue_fds/connector.py
@@ -824,7 +824,7 @@ class FDSRun(WrappedRun):
 
                 # Create NaN masks
                 self._slice_masks[metric_name] = create_obst_mask(
-                    sim.obstructions, slice
+                    self.fds_input_file_path, slice
                 )
 
                 # Record the colorbar this slice should use:

--- a/simvue_fds/connector.py
+++ b/simvue_fds/connector.py
@@ -728,13 +728,16 @@ class FDSRun(WrappedRun):
             try:
                 coords: dict[str, numpy.ndarray] = slice.get_coordinates()
                 dims = slice.extent_dirs
-                values = numpy.full(
-                    (len(slice.times), len(coords[dims[0]]), len(coords[dims[1]])),
-                    numpy.nan,
+                values = numpy.zeros(
+                    (len(slice.times), len(coords[dims[0]]), len(coords[dims[1]]))
                 )
                 # Loop through subslices
                 for subslice in slice.subslices:
                     subslice_vals: numpy.ndarray = subslice.data
+                    obst_mask = subslice.mesh.get_obstruction_mask_slice(
+                        subslice
+                    ).squeeze()
+                    subslice_vals = numpy.where(obst_mask, subslice_vals, numpy.nan)
                     start_idx = []
                     end_idx = []
                     insert_indices = []

--- a/simvue_fds/connector.py
+++ b/simvue_fds/connector.py
@@ -729,6 +729,7 @@ class FDSRun(WrappedRun):
             # Due to edge cases which may break fdsreader, we cover this in a try... except
             try:
                 coords: dict[str, numpy.ndarray] = slice.get_coordinates()
+                times = slice.times
                 dims = slice.extent_dirs
                 values = numpy.zeros(
                     (len(slice.times), len(coords[dims[0]]), len(coords[dims[1]]))
@@ -771,7 +772,7 @@ class FDSRun(WrappedRun):
                         start_idx[0] : start_idx[0] + subslice_expanded.shape[1],
                         start_idx[1] : start_idx[1] + subslice_expanded.shape[2],
                     ] = subslice_expanded
-                times = slice.times
+
             except Exception as e:
                 if not self._grids_defined:
                     logger.warning(

--- a/simvue_fds/connector.py
+++ b/simvue_fds/connector.py
@@ -726,9 +726,47 @@ class FDSRun(WrappedRun):
             # Get the values, coordinates, times
             # Due to edge cases which may break fdsreader, we cover this in a try... except
             try:
-                values, coords = slice.to_global(
-                    masked=True, fill=numpy.nan, return_coordinates=True
+                coords: dict[str, numpy.ndarray] = slice.get_coordinates()
+                dims = slice.extent_dirs
+                values = numpy.full(
+                    (len(slice.times), len(coords[dims[0]]), len(coords[dims[1]])),
+                    numpy.nan,
                 )
+                # Loop through subslices
+                for subslice in slice.subslices:
+                    subslice_vals: numpy.ndarray = subslice.data
+                    start_idx = []
+                    end_idx = []
+                    insert_indices = []
+                    # Loop through dimensions
+                    for i, dim in enumerate(dims):
+                        # Get coords for subslice
+                        sub_coords = subslice.get_coordinates()
+                        # Find indexes in global coords where subslice coords start and end
+                        start_idx.append(
+                            numpy.where(coords[dim] == sub_coords[dim][0])[0][0]
+                        )
+                        end_idx.append(
+                            numpy.where(coords[dim] == sub_coords[dim][-1])[0][0]
+                        )
+
+                        # Cut global coords to be same start and end as subslice coords
+                        trimmed_all_coords = coords[dim][start_idx[i] : end_idx[i] + 1]
+                        # Could use searchsorted to find indexes to insert elements into to maintain order of coords
+                        insert_indices.append(
+                            numpy.searchsorted(sub_coords[dim], trimmed_all_coords)
+                        )
+
+                    # Expand subslice values using the indices which maintain order
+                    subslice_expanded = subslice_vals[
+                        :, insert_indices[0][:, None], insert_indices[1][None, :]
+                    ]
+                    # Insert into correct place in grid
+                    values[
+                        :,
+                        start_idx[0] : start_idx[0] + subslice_expanded.shape[1],
+                        start_idx[1] : start_idx[1] + subslice_expanded.shape[2],
+                    ] = subslice_expanded
                 times = slice.times
             except Exception as e:
                 if not self._grids_defined:

--- a/simvue_fds/connector.py
+++ b/simvue_fds/connector.py
@@ -36,6 +36,8 @@ from fdsreader.slcf.slice import Slice
 from simvue_connector.connector import WrappedRun
 from simvue_connector.extras.create_command import format_command_env_vars
 
+from simvue_fds.helpers import create_obst_mask
+
 logger = logging.getLogger(__name__)
 MAXIMUM_SLICE_SIZE: int = 50000
 
@@ -733,14 +735,13 @@ class FDSRun(WrappedRun):
                 )
                 # Loop through subslices
                 for subslice in slice.subslices:
-                    subslice_vals: numpy.ndarray = subslice.data
-                    obst_mask = subslice.mesh.get_obstruction_mask_slice(
-                        subslice
-                    ).squeeze()
-                    subslice_vals = numpy.where(obst_mask, subslice_vals, numpy.nan)
                     start_idx = []
                     end_idx = []
                     insert_indices = []
+
+                    # Get subslice data
+                    subslice_vals: numpy.ndarray = subslice.data
+
                     # Loop through dimensions
                     for i, dim in enumerate(dims):
                         # Get coords for subslice
@@ -779,13 +780,6 @@ class FDSRun(WrappedRun):
                     logger.debug(e)
                 continue
 
-            # In some cases, fdsreader returns two arrays which are a tiny offset from each other due to mesh boundaries
-            # We will just use the first one, since they should be almost identical...
-            if isinstance(values, tuple):
-                values = values[0]
-            if isinstance(coords, tuple):
-                coords = coords[0]
-
             # Get rid of values already uploaded, return if nothing left to upload
             values = values[self._slice_processed_idx :, ...]
             if values.shape[0] == 0:
@@ -804,7 +798,7 @@ class FDSRun(WrappedRun):
             if metric_name in self._grids_too_large:
                 continue
 
-            # Define grid if first pass
+            # Define grid and NaN mask if first pass
             if metric_name not in self._grids_defined:
                 # Check size doesn't breach server limit
                 if (
@@ -828,6 +822,11 @@ class FDSRun(WrappedRun):
                 )
                 self._grids_defined.append(metric_name)
 
+                # Create NaN masks
+                self._slice_masks[metric_name] = create_obst_mask(
+                    sim.obstructions, slice
+                )
+
                 # Record the colorbar this slice should use:
                 self.update_metadata(
                     {
@@ -843,8 +842,14 @@ class FDSRun(WrappedRun):
                     }
                 )
 
-            if metric_name not in self._grids_defined:
+            if (
+                metric_name not in self._grids_defined
+                or metric_name not in self._slice_masks
+            ):
                 continue
+
+            # Apply NaN mask for OBSTs
+            values[:, self._slice_masks[metric_name]] = numpy.nan
 
             times_to_process = times[self._slice_processed_idx :]
             for time_idx, time_val in enumerate(times_to_process):
@@ -955,6 +960,7 @@ class FDSRun(WrappedRun):
         self._fds_start_time: float | None = None
         self._fds_end_time: float | None = None
         self._simulation_start_time: float = datetime.now().timestamp()
+        self._slice_masks = {}
 
         # Need this so that we dont get spammed with non-critical timestamp warning from fdsreader
         fdsreader.settings.IGNORE_ERRORS = True

--- a/simvue_fds/helpers.py
+++ b/simvue_fds/helpers.py
@@ -5,10 +5,63 @@ import numpy
 from fdsreader.slcf.slice import Slice
 
 
+def create_heterogeneous_slice(
+    slice: Slice,
+) -> tuple[dict[str, numpy.ndarray], numpy.ndarray]:
+    """Create a single array of values for a slice, with heterogeneous mesh sizes.
+
+    As opposed to fdsreader's `to_global()` method, this function will only make the coarse
+    mesh finer around areas which are required to maintain a constant sized 2D array. This
+    results in a much less sparse array, saving memory.
+
+    When making the mesh finer in a section, values are repeated to reconstruct the appearance
+    of a coarser mesh.
+    """
+    coords: dict[str, numpy.ndarray] = slice.get_coordinates()
+    dims = slice.extent_dirs
+    values = numpy.zeros((len(slice.times), len(coords[dims[0]]), len(coords[dims[1]])))
+    # Loop through subslices
+    for subslice in slice.subslices:
+        start_idx = []
+        end_idx = []
+        insert_indices = []
+
+        # Get subslice data
+        subslice_vals: numpy.ndarray = subslice.data
+
+        # Loop through dimensions
+        for i, dim in enumerate(dims):
+            # Get coords for subslice
+            sub_coords = subslice.get_coordinates()
+            # Find indexes in global coords where subslice coords start and end
+            start_idx.append(numpy.where(coords[dim] == sub_coords[dim][0])[0][0])
+            end_idx.append(numpy.where(coords[dim] == sub_coords[dim][-1])[0][0])
+
+            # Cut global coords to be same start and end as subslice coords
+            trimmed_all_coords = coords[dim][start_idx[i] : end_idx[i] + 1]
+            # Could use searchsorted to find indexes to insert elements into to maintain order of coords
+            insert_indices.append(
+                numpy.searchsorted(sub_coords[dim], trimmed_all_coords)
+            )
+
+        # Expand subslice values using the indices which maintain order
+        subslice_expanded = subslice_vals[
+            :, insert_indices[0][:, None], insert_indices[1][None, :]
+        ]
+        # Insert into correct place in grid
+        values[
+            :,
+            start_idx[0] : start_idx[0] + subslice_expanded.shape[1],
+            start_idx[1] : start_idx[1] + subslice_expanded.shape[2],
+        ] = subslice_expanded
+
+    return coords, values
+
+
 def create_obst_mask(file_path: str, slice: Slice) -> numpy.ndarray:
     """Create a boolean mask of OBSTs for a given slice through the mesh.
 
-    Note that this OBST blocks which touch, but do not cross, the slice are not included.
+    Note that OBST blocks which touch, but do not cross, the slice are not included.
 
     Parameters
     ----------

--- a/simvue_fds/helpers.py
+++ b/simvue_fds/helpers.py
@@ -1,6 +1,46 @@
 """Helpers for extracting useful information from FDS files."""
 
 import f90nml
+import numpy
+
+
+def create_obst_mask(obstructions, slice):
+    all_coords = slice.get_coordinates()
+    dims = slice.extent_dirs
+    mask = numpy.full((len(all_coords[dims[0]]), len(all_coords[dims[1]])), False)
+
+    if "x" not in dims:
+        fixed_val = all_coords["x"][0]
+        fixed_idx = 0
+    elif "y" not in dims:
+        fixed_val = all_coords["y"][0]
+        fixed_idx = 2
+    else:
+        fixed_val = all_coords["z"][0]
+        fixed_idx = 4
+
+    for obst in obstructions:
+        obst_coords = obst.bounding_box.as_list(reduced=False)
+        # Check if obst exists over fixed dim
+        if (
+            obst_coords[fixed_idx] < fixed_val
+            and obst_coords[fixed_idx + 1] > fixed_val
+        ):
+            obst_coords.pop(fixed_idx + 1)
+            obst_coords.pop(fixed_idx)
+
+            i_start = numpy.searchsorted(all_coords[dims[0]], obst_coords[0])
+            i_end = numpy.searchsorted(all_coords[dims[0]], obst_coords[1])
+
+            j_start = numpy.searchsorted(all_coords[dims[1]], obst_coords[2])
+            j_end = numpy.searchsorted(all_coords[dims[1]], obst_coords[3])
+
+            # Replace coords with NaNs
+            mask[
+                i_start:i_end,
+                j_start:j_end,
+            ] = True
+    return mask
 
 
 def read_obst_rectangles(
@@ -107,6 +147,7 @@ def read_obst_rectangles(
         for key, val in nml.items():
             if key.lower() == "obst":
                 coords = val["xb"]
+                print(coords)
 
                 if base < coords[5] and top > coords[4]:
                     rects.append(

--- a/simvue_fds/helpers.py
+++ b/simvue_fds/helpers.py
@@ -34,10 +34,14 @@ def create_obst_mask(input_file_path, slice):
             obst_coords.pop(fixed_idx)
 
             i_start = numpy.searchsorted(all_coords[dims[0]], obst_coords[0])
-            i_end = numpy.searchsorted(all_coords[dims[0]], obst_coords[1])
+            i_end = numpy.searchsorted(
+                all_coords[dims[0]], obst_coords[1], side="right"
+            )
 
             j_start = numpy.searchsorted(all_coords[dims[1]], obst_coords[2])
-            j_end = numpy.searchsorted(all_coords[dims[1]], obst_coords[3])
+            j_end = numpy.searchsorted(
+                all_coords[dims[1]], obst_coords[3], side="right"
+            )
 
             # Replace coords with NaNs
             mask[

--- a/simvue_fds/helpers.py
+++ b/simvue_fds/helpers.py
@@ -2,13 +2,35 @@
 
 import f90nml
 import numpy
+from fdsreader.slcf.slice import Slice
 
 
-def create_obst_mask(input_file_path, slice):
+def create_obst_mask(file_path: str, slice: Slice) -> numpy.ndarray:
+    """Create a boolean mask of OBSTs for a given slice through the mesh.
+
+    Note that this OBST blocks which touch, but do not cross, the slice are not included.
+
+    Parameters
+    ----------
+    file_path : str
+        Path to the FDS input file.
+
+    slice: Slice
+        The slice to create a mask for, loaded by fdsreader
+
+    Returns
+    -------
+    mask: numpy.ndarray
+        A boolean mask representing areas covered by OBSTs
+
+
+    """
+    # Load coordinates from the slice
     all_coords = slice.get_coordinates()
     dims = slice.extent_dirs
     mask = numpy.full((len(all_coords[dims[0]]), len(all_coords[dims[1]])), False)
 
+    # Find which dimension of the slice is a fixed value
     if "x" not in dims:
         fixed_val = all_coords["x"][0]
         fixed_idx = 0
@@ -19,8 +41,10 @@ def create_obst_mask(input_file_path, slice):
         fixed_val = all_coords["z"][0]
         fixed_idx = 4
 
-    # TEMP use input file instead of fdsreader obsts
-    nml = f90nml.read(input_file_path)
+    # Load FDS input file and loop through obstruction lines
+    # Note that we do this instead of using `simulation.obstructions` from fdsreader,
+    # as that seems to be inaccurate
+    nml = f90nml.read(file_path)
     for key, val in nml.items():
         if key.lower() != "obst":
             continue
@@ -30,9 +54,12 @@ def create_obst_mask(input_file_path, slice):
             obst_coords[fixed_idx] < fixed_val
             and obst_coords[fixed_idx + 1] > fixed_val
         ):
+            # Remove fixed dimension coordinates from obst line
             obst_coords.pop(fixed_idx + 1)
             obst_coords.pop(fixed_idx)
 
+            # Find indexes which correspond to the start and end points of the OBST within the slice
+            # If the OBST does not exist inside the slice, it will return two equal values
             i_start = numpy.searchsorted(all_coords[dims[0]], obst_coords[0])
             i_end = numpy.searchsorted(
                 all_coords[dims[0]], obst_coords[1], side="right"
@@ -43,11 +70,14 @@ def create_obst_mask(input_file_path, slice):
                 all_coords[dims[1]], obst_coords[3], side="right"
             )
 
-            # Replace coords with NaNs
+            # Slice to replace OBSTs with True in the mask
+            # If values above are equal nothing will happen,
+            # hence this does not affect OBSTs which dont intersect the slice
             mask[
                 i_start:i_end,
                 j_start:j_end,
             ] = True
+
     return mask
 
 

--- a/simvue_fds/helpers.py
+++ b/simvue_fds/helpers.py
@@ -29,10 +29,11 @@ def create_heterogeneous_slice(
         # Get subslice data
         subslice_vals: numpy.ndarray = subslice.data
 
+        # Get coords for subslice
+        sub_coords = subslice.get_coordinates()
+
         # Loop through dimensions
         for i, dim in enumerate(dims):
-            # Get coords for subslice
-            sub_coords = subslice.get_coordinates()
             # Find indexes in global coords where subslice coords start and end
             start_idx.append(numpy.where(coords[dim] == sub_coords[dim][0])[0][0])
             end_idx.append(numpy.where(coords[dim] == sub_coords[dim][-1])[0][0])
@@ -238,7 +239,6 @@ def read_obst_rectangles(
         for key, val in nml.items():
             if key.lower() == "obst":
                 coords = val["xb"]
-                print(coords)
 
                 if base < coords[5] and top > coords[4]:
                     rects.append(

--- a/simvue_fds/helpers.py
+++ b/simvue_fds/helpers.py
@@ -4,7 +4,7 @@ import f90nml
 import numpy
 
 
-def create_obst_mask(obstructions, slice):
+def create_obst_mask(input_file_path, slice):
     all_coords = slice.get_coordinates()
     dims = slice.extent_dirs
     mask = numpy.full((len(all_coords[dims[0]]), len(all_coords[dims[1]])), False)
@@ -19,8 +19,12 @@ def create_obst_mask(obstructions, slice):
         fixed_val = all_coords["z"][0]
         fixed_idx = 4
 
-    for obst in obstructions:
-        obst_coords = obst.bounding_box.as_list(reduced=False)
+    # TEMP use input file instead of fdsreader obsts
+    nml = f90nml.read(input_file_path)
+    for key, val in nml.items():
+        if key.lower() != "obst":
+            continue
+        obst_coords = list(val["xb"])
         # Check if obst exists over fixed dim
         if (
             obst_coords[fixed_idx] < fixed_val

--- a/tests/integration/test_fds.py
+++ b/tests/integration/test_fds.py
@@ -250,7 +250,8 @@ def test_fds_supply_exhaust(folder_setup, offline_cache_setup, load, offline, pa
 
     # Check fire obstructions uploaded as NaNs (come back as None's over API)
     # Obstruction is on the floor (z=0) from x=1.3 to x=1.7
-    assert all(arr[0, 13:17] == None)
+    # Edges of obstructions not marked as NaNs, so cells 1.4m - 1.6m should be marked NaN
+    assert all(arr[0, 14:17] == None)
 
     # Check line DEVC uploaded as 2D metric
     _user_config: SimvueConfiguration = SimvueConfiguration.fetch(mode="online")


### PR DESCRIPTION
# New Connector Feature - Heterogeneous Meshes

## Description of Feature
Instead of using fdsreader's `to_global()` method to create our grid metrics for a slice (which creates a homogeneous mesh at the same granularity of the finest mesh present), we create a heterogeneous mesh of different fineness levels, only increasing the granularity of coarse meshes where strictly necessary to maintain a constant sized 2D array.

Also adds custom OBST parsing to create a NaN mask - the built in version from fdsreader is very prone to bugs and misses a large number of OBSTs.

## Testing Performed
- **Tested Software Version(s)**: 6.9.1
- **Tested Operating System(s)**: Ubuntu 24.04
- **Tested Python Version(s)**: 3.12
- **Tested Simvue Python API Version(s)**: 2.4.1

## Links to Issues
Closes #65, Closes #66

## Checklist
- [ ] Code corresponds to the guidelines set out in the Contributing.md document
- [ ] Any new Python package requirements have been added as an Extra to the `pyproject.toml`
- [ ] Unit tests have been added which check all functionality of the new feature, using Mock functions to replicate the simulation software
- [ ] All unit tests run and pass locally
- [ ] Integration tests have been updated to use the new feature and are passing in the CI
- [ ] Code passes all pre-commit hooks
- [ ] The `Integrations` and `Examples` pages of the documentation have been updated to include information about your new feature (if applicable)
- [ ] Example scripts have been updated to include your new feature
